### PR TITLE
Load jinja Environment lazily and cache it

### DIFF
--- a/viewlet/loaders/jinja2_loader.py
+++ b/viewlet/loaders/jinja2_loader.py
@@ -41,16 +41,21 @@ def create_env():
     env = Environment(loader=ChoiceLoader(loaders), extensions=[ViewletExtension])
     return env
 
+_env = None
 
 def get_env():
+    global _env
+    if _env:
+        return _env
+
     jinja2_env_module = settings.VIEWLET_JINJA2_ENVIRONMENT
     module, environment = jinja2_env_module.rsplit('.', 1)
     imported_module = import_module(module)
     jinja2_env = getattr(imported_module, environment)
     if callable(jinja2_env):
         jinja2_env = jinja2_env()
+    _env = jinja2_env
     return jinja2_env
-env = get_env()
 
 
 def render_to_string(template_name, context):
@@ -58,7 +63,7 @@ def render_to_string(template_name, context):
 
 
 def get_template(template_name):
-    return env.get_template(template_name)
+    return get_env().get_template(template_name)
 
 
 def mark_safe(value):

--- a/viewlet/tests/test_viewlet.py
+++ b/viewlet/tests/test_viewlet.py
@@ -10,6 +10,7 @@ import viewlet
 from ..exceptions import UnknownViewlet
 from ..cache import get_cache
 from ..conf import settings
+from ..loaders import jinja2_loader
 from ..loaders.jinja2_loader import get_env
 
 cache = get_cache()
@@ -73,15 +74,18 @@ class ViewletTest(TestCase):
             return {
                 'name': name
             }
+    
+    def tearDown(self):
+        jinja2_loader._env = None
+        settings.VIEWLET_JINJA2_ENVIRONMENT = 'viewlet.loaders.jinja2_loader.create_env'
 
     def get_django_template(self, source):
         return '\n'.join(('{% load viewlets %}',
                           source))
 
     def get_jinja_template(self, source):
-        from ..loaders.jinja2_loader import env
         settings.VIEWLET_TEMPLATE_ENGINE = 'jinja2'
-        return env.from_string(source)
+        return get_env().from_string(source)
 
     def render(self, source, context=None):
         return get_template_from_string(source).render(Context(context or {})).strip()
@@ -166,6 +170,7 @@ class ViewletTest(TestCase):
         self.assertEqual(env.optimized, True)
         self.assertEqual(env.autoescape, False)
         settings.VIEWLET_JINJA2_ENVIRONMENT = 'coffin.common.env'
+        jinja2_loader._env = None
         env = get_env()
         self.assertEqual(env.optimized, False)
         # Jingo does not support django <= 1.2


### PR DESCRIPTION
This avoids a circular dependency when a project's jinja Environment is declared at the module level and depends on django settings (since django-viewlet imports the Environment at project startup).

I have a project where I don't use either jingo or coffin, but instead I've rolled my own jinja2 integration. In this project I declare my jinja Environment at the module level like this:

``` python
env = Environment(
    loader=FileSystemLoader(settings.JINJA_TEMPLATE_DIRS),
    extensions=settings.JINJA_EXTENSIONS,
    autoescape=True,
)
```

This doesn't work with the current version of viewlet, but this pull request fixes it.

I made these changes pretty fast without too much insight in the code base, so please look them through if you're going to merge them :). All tests passes at least.
